### PR TITLE
Bump Music Assistant library to 1.0.14

### DIFF
--- a/custom_components/mass/manifest.json
+++ b/custom_components/mass/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://github.com/music-assistant/hass-music-assistant",
   "issue_tracker": "https://github.com/music-assistant/hass-music-assistant/issues",
   "requirements": [
-    "music-assistant==1.0.13"
+    "music-assistant==1.0.14"
   ],
   "codeowners": [
     "@marcelveldt"


### PR DESCRIPTION
https://github.com/music-assistant/music-assistant-lib/releases/tag/1.0.14

Update spotify provider (https://github.com/music-assistant/music-assistant-lib/pull/265) @marcelveldt
Fix errors while updating existing items (https://github.com/music-assistant/music-assistant-lib/pull/264) @marcelveldt
Improve filesystem music provider (https://github.com/music-assistant/music-assistant-lib/pull/263) @marcelveldt