### PR TITLE
Fix playback

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,4 @@ updates:
   - package-ecosystem: "npm"
     directory: "/custom_components/mass/frontend/"
     schedule:
-      interval: daily
+      interval: weekly

--- a/custom_components/mass/player_controls.py
+++ b/custom_components/mass/player_controls.py
@@ -14,6 +14,7 @@ from homeassistant.components.media_player.const import (
 )
 from homeassistant.components.media_player.const import DOMAIN as MEDIA_PLAYER_DOMAIN
 from homeassistant.components.media_player.const import (
+    MEDIA_TYPE_MUSIC,
     SERVICE_PLAY_MEDIA,
     SUPPORT_PLAY_MEDIA,
 )
@@ -53,7 +54,6 @@ from .const import (
     SLIMPROTO_DOMAIN,
     SLIMPROTO_EVENT,
 )
-from .media_source import MEDIA_CONTENT_TYPE_FLAC
 
 OFF_STATES = [STATE_OFF, STATE_UNAVAILABLE, STATE_UNKNOWN, STATE_STANDBY]
 UNAVAILABLE_STATES = [STATE_UNAVAILABLE, STATE_UNKNOWN]
@@ -160,7 +160,7 @@ class HassPlayer(Player):
             MP_DOMAIN,
             SERVICE_PLAY_MEDIA,
             {
-                ATTR_MEDIA_CONTENT_TYPE: MEDIA_CONTENT_TYPE_FLAC,
+                ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_MUSIC,
                 ATTR_MEDIA_CONTENT_ID: url,
                 "entity_id": self.entity_id,
             },

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,5 +7,5 @@ pytest==7.1.2
 pytest-cov==3.0.0
 pytest-timeout==2.1.0
 pre-commit==2.18.1
-homeassistant==2022.4.7
-music-assistant==1.0.21
+homeassistant==2022.5.3
+music-assistant


### PR DESCRIPTION
Turns out a lot of media_player integrations need the content_type field set to "music" instead of the actual content type (e.g. audio/flac). 

fixes #72 