### PR TITLE
Prevent errors when external media is playing on player

### DIFF
--- a/custom_components/mass/frontend/src/components/ItemsListing.vue
+++ b/custom_components/mass/frontend/src/components/ItemsListing.vue
@@ -76,17 +76,8 @@
     >
       <v-progress-linear indeterminate v-if="loading"></v-progress-linear>
       <!-- panel view -->
-      <v-row
-        dense
-        align-content="stretch"
-        align="stretch"
-        v-if="viewMode == 'panel'"
-      >
-        <v-col
-          v-for="item in filteredItems"
-          :key="item.uri"
-          align-self="stretch"
-        >
+      <v-row dense align-content="stretch" align="stretch" v-if="viewMode == 'panel'">
+        <v-col v-for="item in filteredItems" :key="item.uri" align-self="stretch">
           <PanelviewItem
             :item="item"
             :size="thumbSize"
@@ -121,9 +112,7 @@
 
       <!-- show alert if no items found -->
       <v-alert type="info" v-if="!loading && items.length == 0">{{
-        api.jobs.value.length > 0
-          ? $t("no_content_sync_running")
-          : $t("no_content")
+        $t("no_content")
       }}</v-alert>
     </div>
   </section>
@@ -141,14 +130,7 @@ import {
   mdiCheck,
 } from "@mdi/js";
 
-import {
-  watchEffect,
-  ref,
-  computed,
-  onBeforeUnmount,
-  onMounted,
-  nextTick,
-} from "vue";
+import { watchEffect, ref, computed, onBeforeUnmount, onMounted, nextTick } from "vue";
 import { useDisplay } from "vuetify";
 import type {
   Album,
@@ -212,15 +194,9 @@ const filteredItems = computed(() => {
     for (const item of props.items) {
       if (item.name.toLowerCase().includes(searchStr)) {
         result.push(item);
-      } else if (
-        "artist" in item &&
-        item.artist.name.toLowerCase().includes(searchStr)
-      ) {
+      } else if ("artist" in item && item.artist.name.toLowerCase().includes(searchStr)) {
         result.push(item);
-      } else if (
-        "album" in item &&
-        item.album?.name.toLowerCase().includes(searchStr)
-      ) {
+      } else if ("album" in item && item.album?.name.toLowerCase().includes(searchStr)) {
         result.push(item);
       } else if (
         "artists" in item &&
@@ -234,9 +210,7 @@ const filteredItems = computed(() => {
   }
   // sort
   if (sortBy.value == "name") {
-    result.sort((a, b) =>
-      (a.sort_name || a.name).localeCompare(b.sort_name || b.name)
-    );
+    result.sort((a, b) => (a.sort_name || a.name).localeCompare(b.sort_name || b.name));
   }
   if (sortBy.value == "album.name") {
     result.sort((a, b) =>
@@ -255,18 +229,14 @@ const filteredItems = computed(() => {
   }
   if (sortBy.value == "track_number") {
     result.sort(
-      (a, b) =>
-        ((a as Track).disc_number || 0) - ((b as Track).disc_number || 0)
+      (a, b) => ((a as Track).disc_number || 0) - ((b as Track).disc_number || 0)
     );
     result.sort(
-      (a, b) =>
-        ((a as Track).track_number || 0) - ((b as Track).track_number || 0)
+      (a, b) => ((a as Track).track_number || 0) - ((b as Track).track_number || 0)
     );
   }
   if (sortBy.value == "position") {
-    result.sort(
-      (a, b) => ((a as Track).position || 0) - ((b as Track).position || 0)
-    );
+    result.sort((a, b) => ((a as Track).position || 0) - ((b as Track).position || 0));
   }
   if (sortBy.value == "year") {
     result.sort((a, b) => ((a as Album).year || 0) - ((b as Album).year || 0));

--- a/custom_components/mass/frontend/src/components/MediaItemThumb.vue
+++ b/custom_components/mass/frontend/src/components/MediaItemThumb.vue
@@ -1,6 +1,6 @@
 <template>
   <v-img
-    :key="item.uri"
+    :key="item?.uri"
     cover
     :src="imgData"
     :height="height"
@@ -13,7 +13,10 @@
   >
     <template v-slot:placeholder>
       <div class="d-flex align-center justify-center fill-height">
-        <v-progress-circular indeterminate color="grey-lighten-4"></v-progress-circular>
+        <v-progress-circular
+          indeterminate
+          color="grey-lighten-4"
+        ></v-progress-circular>
       </div>
     </template>
   </v-img>
@@ -39,6 +42,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   border: true,
+  size: 200,
 });
 
 const imgData = ref<string>();
@@ -53,8 +57,7 @@ watchEffect(async () => {
   if (!props.item) return;
   const url =
     api?.getImageUrl(props.item) ||
-    api?.getImageUrl(store.contextMenuParentItem) ||
-    (await api?.getImageUrlForMediaItem(props.item.uri));
+    api?.getImageUrl(store.contextMenuParentItem);
 
   if (typeof url == "string" && (!props.size || props.size > 200)) {
     // simply use the fullsize url

--- a/custom_components/mass/frontend/src/components/PlayerOSD.vue
+++ b/custom_components/mass/frontend/src/components/PlayerOSD.vue
@@ -17,10 +17,18 @@
           ? 'to bottom, rgba(0,0,0,.80), rgba(0,0,0,.75)'
           : 'to bottom, rgba(255,255,255,.85), rgba(255,255,255,.65)'
       "
-      style="position: absolute; background-size: 100%; padding: 0; margin-top: -10px"
+      style="
+        position: absolute;
+        background-size: 100%;
+        padding: 0;
+        margin-top: -10px;
+      "
     />
     <!-- now playing media -->
-    <div class="mediadetails" v-if="curMediaItem">
+    <div
+      class="mediadetails"
+      v-if="activePlayerQueue?.active && (curMediaItem || curQueueItem)"
+    >
       <media-item-thumb
         class="mediadetails-thumb"
         :key="curMediaItem.item_id"
@@ -30,7 +38,7 @@
         style="width: 50px; border: 1px solid rgba(0, 0, 0, 0.54)"
       />
 
-      <v-list-item two-line class="mediadetails-title">
+      <v-list-item two-line class="mediadetails-title" v-if="curMediaItem">
         <div>
           <v-list-item-title> {{ curMediaItem.name }}</v-list-item-title>
           <v-list-item-subtitle
@@ -52,6 +60,11 @@
           </v-list-item-subtitle>
         </div>
       </v-list-item>
+      <v-list-item two-line class="mediadetails-title" v-else-if="curQueueItem">
+        <div>
+          <v-list-item-title> {{ curQueueItem.name }}</v-list-item-title>
+        </div>
+      </v-list-item>
 
       <!-- streaming quality details -->
 
@@ -69,22 +82,30 @@
               contain
               :src="iconHiRes"
               height="25"
-              :style="$vuetify.theme.current == 'light' ? 'filter: invert(100%)' : ''"
+              :style="
+                $vuetify.theme.current == 'light' ? 'filter: invert(100%)' : ''
+              "
             />
             <v-img
               v-if="streamDetails.bit_depth <= 16"
               contain
               :src="getContentTypeIcon(streamDetails.content_type)"
               height="25"
-              :style="$vuetify.theme.current == 'light' ? 'filter: invert(100%)' : ''"
+              :style="
+                $vuetify.theme.current == 'light' ? 'filter: invert(100%)' : ''
+              "
             />
           </v-btn>
         </template>
         <v-card class="mx-auto" width="300">
           <v-list style="overflow: hidden">
-            <span class="text-h5" style="padding: 10px">{{ $t("stream_details") }}</span>
+            <span class="text-h5" style="padding: 10px">{{
+              $t("stream_details")
+            }}</span>
             <v-divider></v-divider>
-            <v-list-item style="height: 50px; display: flex; align-items: center">
+            <v-list-item
+              style="height: 50px; display: flex; align-items: center"
+            >
               <img
                 height="30"
                 width="50"
@@ -113,7 +134,8 @@
             <div
               style="height: 50px; display: flex; align-items: center"
               v-if="
-                activePlayerQueue && activePlayerQueue.settings.crossfade_duration > 0
+                activePlayerQueue &&
+                activePlayerQueue.settings.crossfade_duration > 0
               "
             >
               <img
@@ -161,8 +183,12 @@
     </div>
 
     <!-- progress bar -->
-    <div style="width: 100%; height: 5px">
-      <v-progress-linear v-bind:model-value="progress" height="3" color="primary" />
+    <div style="width: 100%; height: 5px" v-if="activePlayerQueue?.active && curQueueItem">
+      <v-progress-linear
+        v-bind:model-value="progress"
+        height="3"
+        color="primary"
+      />
     </div>
 
     <!-- Control buttons -->
@@ -283,7 +309,11 @@ import VolumeControl from "./VolumeControl.vue";
 import MediaItemThumb from "./MediaItemThumb.vue";
 import { formatDuration, truncateString } from "../utils";
 import { useRouter } from "vue-router";
-import { getContentTypeIcon, iconHiRes, getProviderIcon } from "./ProviderIcons.vue";
+import {
+  getContentTypeIcon,
+  iconHiRes,
+  getProviderIcon,
+} from "./ProviderIcons.vue";
 
 const iconCrossfade = new URL("../assets/crossfade.png", import.meta.url).href;
 const iconLevel = new URL("../assets/level.png", import.meta.url).href;
@@ -348,7 +378,7 @@ const getTrackArtists = function (item: Track) {
 watchEffect(async () => {
   if (curQueueItem.value == undefined) {
     curMediaItem.value = undefined;
-  } else {
+  } else if (curQueueItem.value.is_media_item) {
     curMediaItem.value = await api?.getItem(curQueueItem.value.uri);
   }
 });

--- a/custom_components/mass/frontend/src/components/PlayerOSD.vue
+++ b/custom_components/mass/frontend/src/components/PlayerOSD.vue
@@ -173,7 +173,7 @@
           small
           icon
           variant="plain"
-          :disabled="!activePlayerQueue"
+          :disabled="!activePlayerQueue || !activePlayerQueue.current_item"
           @click="api.queueCommandPrevious(activePlayerQueue?.queue_id)"
         >
           <v-icon :icon="mdiSkipPrevious" />
@@ -182,7 +182,7 @@
           icon
           x-large
           variant="plain"
-          :disabled="!activePlayerQueue"
+          :disabled="!activePlayerQueue || !activePlayerQueue.current_item"
           @click="api.queueCommandPlayPause(activePlayerQueue?.queue_id)"
         >
           <v-icon size="50">{{
@@ -193,7 +193,7 @@
           icon
           small
           variant="plain"
-          :disabled="!activePlayerQueue"
+          :disabled="!activePlayerQueue || !activePlayerQueue.next_item"
           @click="api.queueCommandNext(activePlayerQueue?.queue_id)"
         >
           <v-icon :icon="mdiSkipNext" />

--- a/custom_components/mass/frontend/src/plugins/api.ts
+++ b/custom_components/mass/frontend/src/plugins/api.ts
@@ -735,11 +735,6 @@ export class MusicAssistantApi {
     if (fallbackToImage) return this.getImageUrl(mediaItem);
   }
 
-  public async getImageUrlForMediaItem(uri: string) {
-    const fullItem = await this.getItem(uri);
-    return this.getImageUrl(fullItem);
-  }
-
   private async connectHassStandalone() {
     let auth;
     const storeAuth = true;


### PR DESCRIPTION
The frontend tried to resolve unknown media into MediaItem which caused some ugly errors in the logs.
This is now handled