### PR TITLE
Bump music-assistant library to 1.0.28

### DIFF
--- a/custom_components/mass/manifest.json
+++ b/custom_components/mass/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://github.com/music-assistant/hass-music-assistant",
   "issue_tracker": "https://github.com/music-assistant/hass-music-assistant/issues",
   "requirements": [
-    "music-assistant==1.0.26"
+    "music-assistant==1.0.28"
   ],
   "codeowners": [
     "@marcelveldt"


### PR DESCRIPTION
Fixes for several startup errors and better exception handling