### PR TITLE
Forward Queue events on HA eventbus

### DIFF
--- a/custom_components/mass/const.py
+++ b/custom_components/mass/const.py
@@ -2,6 +2,7 @@
 
 
 DOMAIN = "mass"
+DOMAIN_EVENT = f"{DOMAIN}_event"
 
 DEFAULT_NAME = "Music Assistant"
 


### PR DESCRIPTION
Publishes the most important Queue events 1-on-1 on the HA eventbus for others to subscribe.

Event name/type: mass_event


<img width="995" alt="Schermafbeelding 2022-05-10 om 23 57 00" src="https://user-images.githubusercontent.com/6389780/167728497-ca10c5e8-0cb4-42d0-af3d-a1f2fbc4e26d.png">

