### PR TITLE
Extend metadata exchange

### DIFF
--- a/custom_components/mass/__init__.py
+++ b/custom_components/mass/__init__.py
@@ -51,6 +51,7 @@ FORWARD_EVENTS = (
     EventType.QUEUE_ADDED,
     EventType.QUEUE_UPDATED,
     EventType.QUEUE_ITEMS_UPDATED,
+    EventType.QUEUE_TIME_UPDATED,
 )
 
 

--- a/custom_components/mass/player_controls.py
+++ b/custom_components/mass/player_controls.py
@@ -118,7 +118,10 @@ class HassPlayer(Player):
         """Return elapsed time of current playing media in seconds."""
         # we need to return the corrected time here
         if state := self.hass.states.get(self.entity_id):
-            elapsed_time = state.attributes.get(ATTR_MEDIA_POSITION, 0)
+            attr = state.attributes
+            elapsed_time = (
+                attr.get("media_position_mass", attr.get(ATTR_MEDIA_POSITION)) or 0
+            )
             last_upd = state.attributes.get(ATTR_MEDIA_POSITION_UPDATED_AT, utcnow())
             diff = (utcnow() - last_upd).seconds
             return elapsed_time + diff


### PR DESCRIPTION
For player integrations actually interfacing with the data from MA to enrich the media_player entity.

- added time updated event (contains actual elapsed time of current item as int)
- support special attribute with real elapsed time for player 'media_position_mass'

The lib has also been adjusted so that the queueitem now also contains the (base) media item object, for extraction of artist, album etc. 

CC @nagyrobi