### PR TITLE
Remove greenlet hack from manifest

### DIFF
--- a/custom_components/mass/manifest.json
+++ b/custom_components/mass/manifest.json
@@ -5,8 +5,7 @@
   "documentation": "https://github.com/music-assistant/hass-music-assistant",
   "issue_tracker": "https://github.com/music-assistant/hass-music-assistant/issues",
   "requirements": [
-    "music-assistant==1.1.20",
-    "greenlet>=1.1.1"
+    "music-assistant==1.1.20"
   ],
   "codeowners": [
     "@marcelveldt"


### PR DESCRIPTION
Pinning greenlet in the manifest does more harm than good so remove it.