### PR TITLE
Remove greenlet from manifest

### DIFF
--- a/custom_components/mass/manifest.json
+++ b/custom_components/mass/manifest.json
@@ -5,8 +5,7 @@
   "documentation": "https://github.com/music-assistant/hass-music-assistant",
   "issue_tracker": "https://github.com/music-assistant/hass-music-assistant/issues",
   "requirements": [
-    "music-assistant==1.1.20",
-    "greenlet==1.1.2"
+    "music-assistant==1.1.20"
   ],
   "codeowners": [
     "@marcelveldt"


### PR DESCRIPTION
A pinned version of greenlet was added to the manifest in an attempt to fix some issues with armv7/aarch64 supervised installs but that caused more trouble than it solved so remove it.

Users on an unsupported platform getting an error that greenlet can not be installed are basically out of luck as there are no prebuilt wheels available.