### PR TITLE
Force https for media images

### DIFF
--- a/custom_components/mass/frontend/src/components/MediaItemThumb.vue
+++ b/custom_components/mass/frontend/src/components/MediaItemThumb.vue
@@ -142,8 +142,11 @@ export const getImageThumbForItem = async function (
     return `https://images.weserv.nl/?url=${url}&w=200`;
   } else if (url.startsWith("https://")) {
     return url;
-  } else if (url.startsWith("http://")) {
-    // only allow https images!
+  } else if (
+    url.startsWith("http://") &&
+    window.location.protocol == "https:"
+  ) {
+    // require https images if we're hosted as https...
     return url.replace("http://", "https://");
   } else {
     // use image proxy in HA integration to grab thumb

--- a/custom_components/mass/media_player.py
+++ b/custom_components/mass/media_player.py
@@ -309,7 +309,7 @@ class MassPlayer(MassBaseEntity, MediaPlayerEntity):
         """If the image url is remotely accessible."""
         if not self.player.active_queue.active:
             return True
-        return self.media_image_url is None or self.media_image_url.startswith("http")
+        return self.media_image_url is None or self.media_image_url.startswith("https")
 
     async def async_get_media_image(self) -> tuple[bytes | None, str | None]:
         """Fetch media image of current playing image."""


### PR DESCRIPTION
If HA is hosted as HTTPS, also force the media item images to be HTTPS to prevent errors from the browser.