### PR TITLE
Allow players to be unavailable at startup

### DIFF
--- a/custom_components/mass/config_flow.py
+++ b/custom_components/mass/config_flow.py
@@ -95,7 +95,10 @@ def get_players_schema(hass: HomeAssistant, cur_conf: dict) -> vol.Schema:
             continue
         # require some basic features, most important `play_media`
         if not (
-            entity.support_play_media and entity.support_play and entity.support_pause
+            entity.support_play_media
+            and entity.support_play
+            and entity.support_pause
+            and entity.support_volume_set
         ):
             exclude_entities.append(entity_id)
 

--- a/custom_components/mass/frontend/src/components/PlayerSelect.vue
+++ b/custom_components/mass/frontend/src/components/PlayerSelect.vue
@@ -15,9 +15,10 @@
     <v-divider></v-divider>
     <v-expansion-panels v-model="panelItem" focusable accordion flat>
       <v-expansion-panel
-        v-for="player in availablePlayers"
+        v-for="player in sortedPlayers"
         :id="player.player_id"
         :key="player.player_id"
+        :disabled="!player.available"
         flat
       >
         <v-expansion-panel-title
@@ -118,11 +119,11 @@ import { store } from "../plugins/store";
 const panelItem = ref<number | undefined>(undefined);
 
 // computed properties
-const availablePlayers = computed(() => {
+const sortedPlayers = computed(() => {
   const res: Player[] = [];
   for (const player_id in api?.players) {
     const player = api?.players[player_id];
-    if (player?.available) res.push(player);
+    res.push(player);
   }
   return res
     .slice()

--- a/custom_components/mass/media_player.py
+++ b/custom_components/mass/media_player.py
@@ -66,6 +66,7 @@ from .const import (
     ATTR_IS_GROUP,
     ATTR_QUEUE_ITEMS,
     ATTR_SOURCE_ENTITY_ID,
+    CONF_PLAYER_ENTITIES,
     DEFAULT_NAME,
     DOMAIN,
 )
@@ -114,11 +115,14 @@ async def async_setup_entry(
 ) -> None:
     """Set up Music Assistant MediaPlayer(s) from Config Entry."""
     mass: MusicAssistant = hass.data[DOMAIN]
+    allowed_players = config_entry.options.get(CONF_PLAYER_ENTITIES, [])
     added_ids = set()
 
     async def async_add_player(event: MassEvent) -> None:
         """Add MediaPlayerEntity from Music Assistant Player."""
         if event.object_id in added_ids:
+            return
+        if event.object_id not in allowed_players:
             return
         added_ids.add(event.object_id)
         async_add_entities([MassPlayer(mass, event.data)])

--- a/custom_components/mass/player_controls.py
+++ b/custom_components/mass/player_controls.py
@@ -799,25 +799,15 @@ async def async_register_player_control(
     """Register hass media_player entity as player control on Music Assistant."""
 
     # check for existing player first if already registered
-    if player := mass.players.get_player(entity_id, True):
+    if player := mass.players.get_player(entity_id):
         return player
-
-    entity = hass.states.get(entity_id)
-    if entity is None or entity.attributes is None:
-        return
 
     entity_comp = hass.data.get(DATA_INSTANCES, {}).get(MP_DOMAIN)
     if not entity_comp:
-        return
+        return None
     entity: MediaPlayerEntity = entity_comp.get_entity(entity_id)
     if not entity:
-        return
-
-    # require some basic features, most important `play_media`
-    if not entity.support_play_media:
-        return
-    if not entity.support_play or not entity.support_pause:
-        return
+        return None
 
     player = None
     # Integration specific player controls
@@ -847,7 +837,7 @@ async def async_register_player_controls(
             return
 
         # handle existing source player
-        if source_player := mass.players.get_player(entity_id, True):
+        if source_player := mass.players.get_player(entity_id):
             source_player.on_hass_event(event)
             return
         # entity not (yet) registered


### PR DESCRIPTION
This change will allow unavailable players to be loaded into MA were they were filtered out before. The frontend displays unavailable players "greyed out".