### PR TITLE
fix: format `media_position_updated_at` attribute as ISO time

### DIFF
--- a/custom_components/mass/media_player.py
+++ b/custom_components/mass/media_player.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import time
-
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 

--- a/custom_components/mass/media_player.py
+++ b/custom_components/mass/media_player.py
@@ -1,6 +1,8 @@
 """MediaPlayer platform for Music Assistant integration."""
 from __future__ import annotations
 
+import time
+
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
@@ -199,10 +201,14 @@ class MassPlayer(MassBaseEntity, MediaPlayerEntity):
         self._attr_is_volume_muted = player.volume_muted
         if queue is not None:
             self._attr_media_position = queue.elapsed_time
-            self._attr_media_position_updated_at = queue.elapsed_time_last_updated
+            self._attr_media_position_updated_at = time.strftime(
+                "%Y-%m-%dT%H:%M:%S%z", time.gmtime(queue.elapsed_time_last_updated)
+            )
         else:
             self._attr_media_position = player.elapsed_time
-            self._attr_media_position_updated_at = player.elapsed_time_last_updated
+            self._attr_media_position_updated_at = time.strftime(
+                "%Y-%m-%dT%H:%M:%S%z", time.gmtime(player.elapsed_time_last_updated)
+            )
         self._prev_time = self._attr_media_position
         self._update_media_image_url(queue)
         # update current media item infos


### PR DESCRIPTION
Currently the attribute is a timestamp in seconds (because that's what python's `time` uses) which causes some issues when HAss tries to parse it because JavaScript assumes timestamps are in milliseconds. Formatting the time as ISO String (`YYYY-mm-DDTHH:MM+HHMM`) makes parsing errors much less likely. 

Closes #1401