### PR TITLE
Accept float for seek position [Fixes #1439]

### DIFF
--- a/custom_components/mass/media_player.py
+++ b/custom_components/mass/media_player.py
@@ -283,8 +283,9 @@ class MassPlayer(MassBaseEntity, MediaPlayerEntity):
         else:
             await self.mass.players.queue_command_previous(self.player_id)
 
-    async def async_media_seek(self, position: int) -> None:
+    async def async_media_seek(self, position: float) -> None:
         """Send seek command."""
+        position = int(position)
         if queue := self.mass.players.get_player_queue(self.player.active_source):
             await self.mass.players.queue_command_seek(queue.queue_id, position)
         else:


### PR DESCRIPTION
The MediaPlayerEntity defines the seek position as a `float`, but the mass entity is defining it as an `int`. The type hint is ignored and the value is passed through as a float, which then fails validation on the server-side at `PlayerQueuesController.seek()`.

For now the simplest solution is to truncate the extra precision and pass it through as an int.