### PR TITLE
Fix #1781: compact_items expects dict but sometimes passed list

### DIFF
--- a/custom_components/mass/services.py
+++ b/custom_components/mass/services.py
@@ -59,14 +59,16 @@ def register_services(hass: HomeAssistant) -> None:
                     item[key] = compact_item(value)
                 elif isinstance(value, list):
                     for subitem in value:
-                        compact_item(subitem)
+                        if isinstance(subitem, dict):
+                            compact_item(subitem)
                     # item[key] = [compact_item(x) if isinstance(x, dict) else x for x in value]
             return item
 
         dict_result: dict[str, list[dict[str, Any]]] = result.to_dict()
         for media_type_key in dict_result:
             for item in dict_result[media_type_key]:
-                compact_item(item)
+                if isinstance(item, dict):
+                    compact_item(item)
         return dict_result
 
     hass.services.async_register(

--- a/custom_components/mass/services.py
+++ b/custom_components/mass/services.py
@@ -59,16 +59,18 @@ def register_services(hass: HomeAssistant) -> None:
                     item[key] = compact_item(value)
                 elif isinstance(value, list):
                     for subitem in value:
-                        if isinstance(subitem, dict):
-                            compact_item(subitem)
+                        if not isinstance(subitem, dict):
+                            continue
+                        compact_item(subitem)
                     # item[key] = [compact_item(x) if isinstance(x, dict) else x for x in value]
             return item
 
         dict_result: dict[str, list[dict[str, Any]]] = result.to_dict()
         for media_type_key in dict_result:
             for item in dict_result[media_type_key]:
-                if isinstance(item, dict):
-                    compact_item(item)
+                if not isinstance(item, dict):
+                    continue
+                compact_item(item)
         return dict_result
 
     hass.services.async_register(


### PR DESCRIPTION
This pull request fixes #1781 by implementing a simple type check before invoking `compact_items`. I wasn't able to find any docs on preferences for contributing, so please shoot this back to me if any changes are needed!

**Summary:**
With Spotify connected, running the `mass.search` service causes an error to occur if `track` is passed as a `media_type`. This occurs because the `compact_items` function in `mass/services.py` expects and is type hinted to exclusively accept a dictionary, but when called from `handle_search` or recursively from within `compact_items`, no check is performed to ensure the correct type is passed. This usually does not cause errors, but in some circumstances lists are passed, in the case of the below example for the `external_ids` field.

**Recreation YAML:**
```yaml
service: mass.search
data:
  limit: 5
  name: Pink Floyd
  media_type:
    - track
```

**Error:**
The error `TypeError: pop expected at most 1 argument, got 2` is thrown because `list.pop` expects a single index whereas `dict.pop` expects a key and optionally a default value. This causes improper arguments to be passed when a list is given to `compact_items`.

**Working Local Demonstration:**
![image](https://github.com/music-assistant/hass-music-assistant/assets/14115132/65472ae7-6719-492e-891e-7d164b55212f)