### PR TITLE
Adopt changes to server for announcements

### DIFF
--- a/custom_components/mass/config_flow.py
+++ b/custom_components/mass/config_flow.py
@@ -30,7 +30,6 @@ from .const import (
     CONF_ASSIST_AUTO_EXPOSE_PLAYERS,
     CONF_INTEGRATION_CREATED_ADDON,
     CONF_OPENAI_AGENT_ID,
-    CONF_PRE_ANNOUNCE_TTS,
     CONF_USE_ADDON,
     DOMAIN,
     LOGGER,
@@ -400,7 +399,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     CONF_ASSIST_AUTO_EXPOSE_PLAYERS: user_input[
                         CONF_ASSIST_AUTO_EXPOSE_PLAYERS
                     ],
-                    CONF_PRE_ANNOUNCE_TTS: user_input[CONF_PRE_ANNOUNCE_TTS],
                 },
             )
             await self.hass.config_entries.async_reload(self.config_entry.entry_id)
@@ -435,10 +433,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     is not None
                     else False
                 ),
-            ): bool,
-            vol.Optional(
-                CONF_PRE_ANNOUNCE_TTS,
-                default=config_entry.data.get(CONF_PRE_ANNOUNCE_TTS, False),
             ): bool,
         }
 

--- a/custom_components/mass/manifest.json
+++ b/custom_components/mass/manifest.json
@@ -16,7 +16,7 @@
     "music_assistant"
   ],
   "requirements": [
-    "music-assistant==2.0.0b112"
+    "music-assistant==2.0.0b125"
   ],
   "version": "0.0.0",
   "zeroconf": [

--- a/custom_components/mass/media_player.py
+++ b/custom_components/mass/media_player.py
@@ -55,7 +55,6 @@ from .const import (
     ATTR_QUEUE_INDEX,
     ATTR_QUEUE_ITEMS,
     ATTR_STREAM_TITLE,
-    CONF_PRE_ANNOUNCE_TTS,
     DOMAIN,
 )
 from .entity import MassBaseEntity
@@ -108,6 +107,8 @@ ATTR_MEDIA_ID = "media_id"
 ATTR_MEDIA_TYPE = "media_type"
 ATTR_ARTIST = "artist"
 ATTR_ALBUM = "album"
+ATTR_USE_PRE_ANNOUNCE = "use_pre_announce"
+ATTR_ANNOUNCE_VOLUME = "announce_volume"
 
 # pylint: disable=too-many-public-methods
 
@@ -151,6 +152,8 @@ async def async_setup_entry(
             vol.Optional(ATTR_ARTIST): cv.string,
             vol.Optional(ATTR_ALBUM): cv.string,
             vol.Optional(ATTR_RADIO_MODE): vol.Coerce(bool),
+            vol.Optional(ATTR_USE_PRE_ANNOUNCE): vol.Coerce(bool),
+            vol.Optional(ATTR_ANNOUNCE_VOLUME): vol.Coerce(int),
         },
         "_async_play_media_advanced",
     )
@@ -437,6 +440,8 @@ class MassPlayer(MassBaseEntity, MediaPlayerEntity):
             announce=announce,
             media_type=media_type,
             radio_mode=kwargs[ATTR_MEDIA_EXTRA].get(ATTR_RADIO_MODE),
+            use_pre_announce=kwargs[ATTR_MEDIA_EXTRA].get("use_pre_announce"),
+            announce_volume=kwargs[ATTR_MEDIA_EXTRA].get("announce_volume"),
         )
 
     async def async_join_players(self, group_members: list[str]) -> None:
@@ -469,17 +474,15 @@ class MassPlayer(MassBaseEntity, MediaPlayerEntity):
         announce: bool | None = None,
         radio_mode: bool | None = None,
         media_type: str | None = None,
+        use_pre_announce: bool | None = None,
+        announce_volume: int | None = None,
     ) -> None:
         """Send the play_media command to the media player."""
         # pylint: disable=too-many-arguments
         # announce/alert support
         if announce:
-            conf_entry = self.hass.config_entries.async_get_entry(
-                self.registry_entry.config_entry_id
-            )
-            use_pre_announce = conf_entry.data.get(CONF_PRE_ANNOUNCE_TTS) is True
             await self.mass.players.play_announcement(
-                self.player_id, media_id[0], use_pre_announce
+                self.player_id, media_id[0], use_pre_announce, announce_volume
             )
             return
         media_uris: list[str] = []

--- a/custom_components/mass/services.yaml
+++ b/custom_components/mass/services.yaml
@@ -46,6 +46,25 @@ play_media:
       example: "true"
       selector:
         boolean:
+    use_pre_announce:
+      filter:
+        supported_features:
+          - media_player.MediaPlayerEntityFeature.MEDIA_ANNOUNCE
+      required: false
+      example: "true"
+      selector:
+        boolean:
+    announce_volume:
+      filter:
+        supported_features:
+          - media_player.MediaPlayerEntityFeature.MEDIA_ANNOUNCE
+      required: false
+      example: 75
+      selector:
+        number:
+          min: 1
+          max: 100
+          step: 1
     artist:
       required: false
       example: "Queen"
@@ -61,7 +80,6 @@ play_media:
       advanced: true
       selector:
         boolean:
-
 
 search:
   fields:

--- a/custom_components/mass/strings.json
+++ b/custom_components/mass/strings.json
@@ -91,6 +91,14 @@
           "name": "Announce",
           "description": "If the media should be played as an announcement."
         },
+        "use_pre_announce": {
+          "name": "Use pre-announce",
+          "description": "Use pre-announcement sound for the announcement. Used with the announce option, omit to use player default."
+        },
+        "announce_volume": {
+          "name": "Announce volume",
+          "description": "Use a forced volume level for the announcement. Used with the announce option, omit to use player default."
+        },
         "artist": {
           "name": "Artist name",
           "description": "When specifying a track or album by name in the Media ID field, you can optionally restrict results by this artist name."
@@ -150,8 +158,7 @@
         "data": {
           "url": "URL of the Music Assistant server",
           "use_addon": "Use the official Music Assistant Server add-on",
-          "expose_players_assist": "Expose players to Assist",
-          "pre_announce_tts": "Prepend notification sound to TTS announcements"
+          "expose_players_assist": "Expose players to Assist"
         }
       }
     }

--- a/custom_components/mass/translations/en.json
+++ b/custom_components/mass/translations/en.json
@@ -91,6 +91,14 @@
           "name": "Announce",
           "description": "If the media should be played as an announcement."
         },
+        "use_pre_announce": {
+          "name": "Use pre-announce",
+          "description": "Use pre-announcement sound for the announcement. Used with the announce option, omit to use player default."
+        },
+        "announce_volume": {
+          "name": "Announce volume",
+          "description": "Use a forced volume level for the announcement. Used with the announce option, omit to use player default."
+        },
         "artist": {
           "name": "Artist name",
           "description": "When specifying a track or album by name in the Media ID field, you can optionally restrict results by this artist name."
@@ -150,8 +158,7 @@
         "data": {
           "url": "URL of the Music Assistant server",
           "use_addon": "Use the official Music Assistant Server add-on",
-          "expose_players_assist": "Expose players to Assist",
-          "pre_announce_tts": "Prepend notification sound to TTS announcements"
+          "expose_players_assist": "Expose players to Assist"
         }
       }
     }


### PR DESCRIPTION
- settings for announcements (including pre-announce) are now in the MA player config
- removed pre-accounce setting from HA config options
- added override options for announcements in the play_media service call