### PR TITLE
Make MassPlayMediaOnMediaPlayer work directly from the new LLMs in 2024.6 without the need of a separate conversation agent

### DIFF
--- a/custom_components/mass/intent.py
+++ b/custom_components/mass/intent.py
@@ -113,7 +113,7 @@ class MassPlayMediaOnMediaPlayerHandler(intent.IntentHandler):
         intent_obj: intent.Intent,
         slots: intent._SlotsType,
         config_entry: ConfigEntry,
-    ):
+    ) -> MassPlayer:
         name: str | None = slots.get(NAME_SLOT, {}).get(SLOT_VALUE)
         if name == "all":
             # Don't match on name if targeting all entities
@@ -132,7 +132,7 @@ class MassPlayMediaOnMediaPlayerHandler(intent.IntentHandler):
 
     async def _async_query_ai(
         self, intent_obj: intent.Intent, query: str, config_entry: ConfigEntry
-    ):
+    ) -> str:
         service_data: dict[str, Any] = {}
         service_data[ATTR_AGENT_ID] = config_entry.data.get(CONF_OPENAI_AGENT_ID)
         service_data[ATTR_TEXT] = query
@@ -174,12 +174,12 @@ class MassPlayMediaOnMediaPlayerHandler(intent.IntentHandler):
 
         if not states:
             raise intent.IntentHandleError(
-                f"No entities matched for: name={name}, area={area}"
+                f"No entities matched for: name={name}, area_name={area_name}"
             )
 
         if len(states) > 1:
             raise intent.IntentHandleError(
-                f"Multiple entities matched for: name={name}, area={area}"
+                f"Multiple entities matched for: name={name}, area_name={area_name}"
             )
 
         return states[0]

--- a/custom_components/mass/intent.py
+++ b/custom_components/mass/intent.py
@@ -5,18 +5,17 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from music_assistant.common.models.errors import MusicAssistantError
 import voluptuous as vol
-
+from homeassistant.components.conversation import ATTR_AGENT_ID, ATTR_TEXT
 from homeassistant.components.conversation import (
-    ATTR_AGENT_ID,
-    ATTR_TEXT,
     SERVICE_PROCESS as CONVERSATION_SERVICE,
 )
 from homeassistant.components.conversation.const import DOMAIN as CONVERSATION_DOMAIN
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant, State
-from homeassistant.helpers import config_validation as cv, intent
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import intent
+from music_assistant.common.models.errors import MusicAssistantError
 
 from . import DOMAIN
 from .const import CONF_OPENAI_AGENT_ID

--- a/custom_components/mass/intent.py
+++ b/custom_components/mass/intent.py
@@ -5,16 +5,18 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from music_assistant.common.models.errors import MusicAssistantError
 import voluptuous as vol
-from homeassistant.components.conversation import ATTR_AGENT_ID, ATTR_TEXT
+
 from homeassistant.components.conversation import (
+    ATTR_AGENT_ID,
+    ATTR_TEXT,
     SERVICE_PROCESS as CONVERSATION_SERVICE,
 )
 from homeassistant.components.conversation.const import DOMAIN as CONVERSATION_DOMAIN
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant, State
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers import intent
+from homeassistant.helpers import config_validation as cv, intent
 
 from . import DOMAIN
 from .const import CONF_OPENAI_AGENT_ID
@@ -24,6 +26,9 @@ INTENT_PLAY_MEDIA_ON_MEDIA_PLAYER = "MassPlayMediaOnMediaPlayer"
 NAME_SLOT = "name"
 AREA_SLOT = "area"
 QUERY_SLOT = "query"
+ARTIST_SLOT = "artist"
+TRACK_SLOT = "track"
+ALBUM_SLOT = "album"
 SLOT_VALUE = "value"
 
 
@@ -39,51 +44,99 @@ class MassPlayMediaOnMediaPlayerHandler(intent.IntentHandler):
     slot_schema = {
         vol.Any(NAME_SLOT, AREA_SLOT): cv.string,
         vol.Optional(QUERY_SLOT): cv.string,
+        vol.Optional(ARTIST_SLOT): cv.string,
+        vol.Optional(TRACK_SLOT): cv.string,
+        vol.Optional(ALBUM_SLOT): cv.string,
     }
 
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the intent."""
+        response = intent_obj.create_response()
         slots = self.async_validate_slots(intent_obj.slots)
         config_entry = await self._get_loaded_config_entry(intent_obj.hass)
 
-        query: str = slots.get(QUERY_SLOT, {}).get(SLOT_VALUE)
-        if query is not None:
-            service_data: dict[str, Any] = {}
-            service_data[ATTR_AGENT_ID] = config_entry.data.get(CONF_OPENAI_AGENT_ID)
-            service_data[ATTR_TEXT] = query
+        mass_player = await self._async_get_matched_mass_player(
+            intent_obj, slots, config_entry
+        )
 
+        query = slots.get(QUERY_SLOT, {}).get(SLOT_VALUE)
+        if query:
+            if not config_entry.data.get(CONF_OPENAI_AGENT_ID):
+                raise intent.IntentHandleError(
+                    "query requires using a conversation agent"
+                )
+            ai_response = await self._async_query_ai(intent_obj, query, config_entry)
+            try:
+                json_payload = json.loads(ai_response)
+            except json.decoder.JSONDecodeError:
+                response.response_type = intent.IntentResponseType.PARTIAL_ACTION_DONE
+                response.async_set_speech(ai_response)
+                return response
+            media_id = json_payload.get(ATTR_MEDIA_ID)
+            media_type = json_payload.get(ATTR_MEDIA_TYPE)
+        else:
+            artist = slots.get(ARTIST_SLOT, {}).get(SLOT_VALUE, "")
+            track = slots.get(TRACK_SLOT, {}).get(SLOT_VALUE, "")
+            album = slots.get(ALBUM_SLOT, {}).get(SLOT_VALUE, "")
+            if track:
+                media_type = "track"
+                if artist:
+                    media_id = f"{artist} - {track}"
+                else:
+                    media_id = track
+            elif album:
+                media_type = "album"
+                if artist:
+                    media_id = f"{artist} - {album}"
+                else:
+                    media_id = album
+            elif artist:
+                media_type = "artist"
+                media_id = artist
+
+        try:
+            await mass_player.async_play_media(
+                media_type=media_type,
+                media_id=media_id,
+                enqueue=None,
+                extra={ATTR_RADIO_MODE: False},
+            )
+        except MusicAssistantError as err:
+            raise intent.IntentHandleError(err.args[0] if err.args else "") from err
+
+        response.response_type = intent.IntentResponseType.ACTION_DONE
+        response.async_set_speech("Okay")
+        return response
+
+    async def _async_get_matched_mass_player(
+        self,
+        intent_obj: intent.Intent,
+        slots: intent._SlotsType,
+        config_entry: ConfigEntry,
+    ):
         name: str | None = slots.get(NAME_SLOT, {}).get(SLOT_VALUE)
         if name == "all":
             # Don't match on name if targeting all entities
             name = None
-        # Look up area first to fail early
-        area: str | None = None
-        if AREA_SLOT in slots:
-            area = slots[AREA_SLOT][SLOT_VALUE]
-
-        state = await self._get_matched_state(intent_obj, name, area)
-        actual_player = MassPlayer(
+        area_name = slots.get(AREA_SLOT, {}).get(SLOT_VALUE)
+        state = await self._get_matched_state(intent_obj, name, area_name)
+        mass_player = MassPlayer(
             intent_obj.hass.data[DOMAIN][config_entry.entry_id].mass,
             state.attributes.get("mass_player_id"),
         )
-        if actual_player is None:
+        if mass_player is None:
             raise intent.IntentHandleError(
-                f"No entities matched for: name={name}, area={area}"
+                f"No entities matched for: name={name}, area_name={area_name}"
             )
+        return mass_player
 
-        return await self._parse_query_and_return_appropriate_response(
-            intent_obj.hass, service_data, intent_obj, actual_player
-        )
-
-    async def _parse_query_and_return_appropriate_response(
-        self,
-        hass: HomeAssistant,
-        service_data: dict[str, Any],
-        intent_obj: intent.Intent,
-        actual_player: MassPlayer,
-    ) -> intent.IntentResponse:
-        """Get  from the query."""
-        ai_response = await hass.services.async_call(
+    async def _async_query_ai(
+        self, intent_obj: intent.Intent, query: str, config_entry: ConfigEntry
+    ):
+        service_data: dict[str, Any] = {}
+        service_data[ATTR_AGENT_ID] = config_entry.data.get(CONF_OPENAI_AGENT_ID)
+        service_data[ATTR_TEXT] = query
+        ai_response = await intent_obj.hass.services.async_call(
             CONVERSATION_DOMAIN,
             CONVERSATION_SERVICE,
             {**service_data},
@@ -91,41 +144,18 @@ class MassPlayMediaOnMediaPlayerHandler(intent.IntentHandler):
             context=intent_obj.context,
             return_response=True,
         )
-        response = intent_obj.create_response()
+        return ai_response["response"]["speech"]["plain"]["speech"]
 
-        try:
-            json_payload = json.loads(
-                ai_response["response"]["speech"]["plain"]["speech"]
-            )
-            media_id = json_payload.get(ATTR_MEDIA_ID)
-            media_type = json_payload.get(ATTR_MEDIA_TYPE)
-            await actual_player.async_play_media(
-                media_type=media_type,
-                media_id=media_id,
-                enqueue=None,
-                extra={ATTR_RADIO_MODE: False},
-            )
-            response.response_type = intent.IntentResponseType.ACTION_DONE
-            response.async_set_speech("Okay")
-        except json.decoder.JSONDecodeError:
-            clarification_response = ai_response["response"]["speech"]["plain"][
-                "speech"
-            ]
-            response.response_type = intent.IntentResponseType.PARTIAL_ACTION_DONE
-            response.async_set_speech(clarification_response)
-
-        return response
-
-    async def _get_loaded_config_entry(self, hass: HomeAssistant) -> str:
+    async def _get_loaded_config_entry(self, hass: HomeAssistant) -> ConfigEntry:
         """Get the correct config entry."""
         config_entries = hass.config_entries.async_entries(DOMAIN)
         for config_entry in config_entries:
             if config_entry.state == ConfigEntryState.LOADED:
                 return config_entry
-        return None
+        raise intent.IntentHandleError("Music Assistant not loaded")
 
     async def _get_matched_state(
-        self, intent_obj: intent.Intent, name: str | None, area: str | None
+        self, intent_obj: intent.Intent, name: str | None, area_name: str | None
     ) -> State:
         mass_states: set[str] = set()
         initial_states = intent_obj.hass.states.async_all()
@@ -137,7 +167,7 @@ class MassPlayMediaOnMediaPlayerHandler(intent.IntentHandler):
             intent.async_match_states(
                 intent_obj.hass,
                 name=name,
-                area_name=area,
+                area_name=area_name,
                 states=mass_states,
             )
         )

--- a/custom_components/mass/media_player.py
+++ b/custom_components/mass/media_player.py
@@ -252,9 +252,9 @@ class MassPlayer(MassBaseEntity, MediaPlayerEntity):
             and queue.current_item.media_item
             and queue.current_item.media_item.metadata
         ):
-            attrs[
-                ATTR_STREAM_TITLE
-            ] = queue.current_item.media_item.metadata.description
+            attrs[ATTR_STREAM_TITLE] = (
+                queue.current_item.media_item.metadata.description
+            )
         return attrs
 
     async def async_on_update(self) -> None:


### PR DESCRIPTION
Google Generative AI and OpenAI conversation agents in 2024.6 can call registered intents. The LLMs can already infer artist/track/album from the command and we can avoid the need of setting up a separate conversation agent to pass the query. This also saves an LLM request. I tried it with the examples in https://github.com/music-assistant/hass-music-assistant/blob/main/prompt/prompt.txt and the LLM was able to correctly pass the artist/track/album even for the "play the artist that composed the soundtrack of Inception" example. For the "play a list of 5 classic 80's rock tracks" it called MassPlayMediaOnMediaPlayer with query="list of 5 classic 80's rock tracks".

While I was here I refactored the code a bit to make it more readable and improved error handling.