### PR TITLE
Fix browse listings after recent server change

### DIFF
--- a/custom_components/mass/media_browser.py
+++ b/custom_components/mass/media_browser.py
@@ -163,7 +163,7 @@ async def build_playlists_listing(mass: MusicAssistantClient):
                 build_item(mass, item, can_expand=True)
                 # we only grab the first page here because the
                 # HA media browser does not support paging
-                for item in (await mass.music.get_library_playlists(limit=500)).items
+                for item in await mass.music.get_library_playlists(limit=500)
                 if item.available
             ],
             key=lambda x: x.title,
@@ -187,11 +187,9 @@ async def build_playlist_items_listing(mass: MusicAssistantClient, identifier: s
             build_item(mass, item, can_expand=False)
             # we only grab the first page here because the
             # HA media browser does not support paging
-            for item in (
-                await mass.music.get_playlist_tracks(
-                    playlist.item_id, playlist.provider
-                )
-            ).items
+            for item in await mass.music.get_playlist_tracks(
+                playlist.item_id, playlist.provider
+            )
             if item.available
         ],
     )
@@ -214,7 +212,7 @@ async def build_artists_listing(mass: MusicAssistantClient):
                 build_item(mass, artist, can_expand=True)
                 # we only grab the first page here because the
                 # HA media browser does not support paging
-                for artist in (await mass.music.get_library_artists(limit=500)).items
+                for artist in await mass.music.get_library_artists(limit=500)
                 if artist.available
             ],
             key=lambda x: x.title,
@@ -260,7 +258,7 @@ async def build_albums_listing(mass: MusicAssistantClient):
                 build_item(mass, album, can_expand=True)
                 # we only grab the first page here because the
                 # HA media browser does not support paging
-                for album in (await mass.music.get_library_albums(limit=500)).items
+                for album in await mass.music.get_library_albums(limit=500)
                 if album.available
             ],
             key=lambda x: x.title,
@@ -304,7 +302,7 @@ async def build_tracks_listing(mass: MusicAssistantClient):
                 build_item(mass, track, can_expand=False)
                 # we only grab the first page here because the
                 # HA media browser does not support paging
-                for track in (await mass.music.get_library_tracks(limit=500)).items
+                for track in await mass.music.get_library_tracks(limit=500)
                 if track.available
             ],
             key=lambda x: x.title,
@@ -327,7 +325,7 @@ async def build_radio_listing(mass: MusicAssistantClient):
             build_item(mass, track, can_expand=False, media_class=media_class)
             # we only grab the first page here because the
             # HA media browser does not support paging
-            for track in (await mass.music.get_library_radios(limit=500)).items
+            for track in await mass.music.get_library_radios(limit=500)
             if track.available
         ],
     )


### PR DESCRIPTION
Fix the browse listings for the recent change to paged listings.
Requires bump of the client lib once released.