### PR TITLE
Fix string of the url field in play_announcement

### DIFF
--- a/custom_components/mass/strings.json
+++ b/custom_components/mass/strings.json
@@ -75,7 +75,7 @@
       "name": "Play Announcement (advanced)",
       "description": "Play announcement on a Music Assistant player with more fine grained control options.",
       "fields": {
-        "media_id": {
+        "url": {
           "name": "URL",
           "description": "URL to the notification sound."
         },


### PR DESCRIPTION
In `translations/en.json` (which is what is actually used) this string is correct.