### PR TITLE
Add VOLUME_MUTE to the SUPPORTED_FEATURES in media_player.py

### DIFF
--- a/custom_components/mass/media_player.py
+++ b/custom_components/mass/media_player.py
@@ -96,6 +96,7 @@ SUPPORTED_FEATURES = (
     | MediaPlayerEntityFeature.BROWSE_MEDIA
     | MediaPlayerEntityFeature.MEDIA_ENQUEUE
     | MediaPlayerEntityFeature.MEDIA_ANNOUNCE
+    | MediaPlayerEntityFeature.VOLUME_MUTE
 )
 
 STATE_MAPPING = {


### PR DESCRIPTION
Only tested with:
SONOS
UPnP/DLNA

Slimproto (squeezelite) - unmute does not work
I suspect this has something to do with aioslimproto.