### PR TITLE
Add radio mode to sentences and NAME in AREA

### DIFF
--- a/custom_components/mass/intent.py
+++ b/custom_components/mass/intent.py
@@ -134,7 +134,8 @@ class MassPlayMediaAssistHandler(MassIntentHandlerBase):
         self.hass = hass
 
     slot_schema = {
-        vol.Any(NAME_SLOT, AREA_SLOT): cv.string,
+        vol.Optional(NAME_SLOT): cv.string,
+        vol.Optional(AREA_SLOT): cv.string,
         vol.Optional(ARTIST_SLOT): cv.string,
         vol.Optional(TRACK_SLOT): cv.string,
         vol.Optional(ALBUM_SLOT): cv.string,

--- a/custom_components/mass/intent.py
+++ b/custom_components/mass/intent.py
@@ -213,7 +213,8 @@ class MassPlayMediaOnMediaPlayerHandler(MassIntentHandlerBase):
         self.hass = hass
 
     slot_schema = {
-        vol.Any(NAME_SLOT, AREA_SLOT): cv.string,
+        vol.Optional(NAME_SLOT): cv.string,
+        vol.Optional(AREA_SLOT): cv.string,
         vol.Optional(QUERY_SLOT): cv.string,
         vol.Optional(RADIO_MODE_SLOT): cv.string,
     }

--- a/custom_components/mass/intent.py
+++ b/custom_components/mass/intent.py
@@ -39,7 +39,7 @@ TRACK_SLOT = "track"
 ALBUM_SLOT = "album"
 RADIO_SLOT = "radio"
 PLAYLIST_SLOT = "playlist"
-DONT_STOP_SLOT = "dont_stop"
+RADIO_MODE_SLOT = "radio_mode"
 SLOT_VALUE = "value"
 
 
@@ -140,8 +140,7 @@ class MassPlayMediaAssistHandler(MassIntentHandlerBase):
         vol.Optional(ALBUM_SLOT): cv.string,
         vol.Optional(RADIO_SLOT): cv.string,
         vol.Optional(PLAYLIST_SLOT): cv.string,
-        # TODO: Implement dont_stopß
-        # vol.Optional(DONT_STOP_SLOT): cv.boolean,
+        vol.Optional(RADIO_MODE_SLOT): cv.string,
     }
 
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
@@ -159,9 +158,10 @@ class MassPlayMediaAssistHandler(MassIntentHandlerBase):
         album = slots.get(ALBUM_SLOT, {}).get(SLOT_VALUE, "")
         radio = slots.get(RADIO_SLOT, {}).get(SLOT_VALUE, "")
         playlist = slots.get(PLAYLIST_SLOT, {}).get(SLOT_VALUE, "")
-        # TODO: Implement dont_stop
-        # dont_stop = slots.get(DONT_STOP_SLOT, {}).get(SLOT_VALUE, False)
+        radio_mode_text = slots.get(RADIO_MODE_SLOT, {}).get(SLOT_VALUE, "")
         radio_mode = False
+        if radio_mode_text:
+            radio_mode = True
         if track:
             media_item = await mass.music.get_item_by_name(
                 track, artist=artist, album=album, media_type=MediaType.TRACK
@@ -214,6 +214,7 @@ class MassPlayMediaOnMediaPlayerHandler(MassIntentHandlerBase):
     slot_schema = {
         vol.Any(NAME_SLOT, AREA_SLOT): cv.string,
         vol.Optional(QUERY_SLOT): cv.string,
+        vol.Optional(RADIO_MODE_SLOT): cv.string,
     }
 
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
@@ -227,7 +228,10 @@ class MassPlayMediaOnMediaPlayerHandler(MassIntentHandlerBase):
         mass = config_entry.runtime_data.mass
         mass_player_id = await self._async_get_matched_mass_player(intent_obj, slots)
         query = slots.get(QUERY_SLOT, {}).get(SLOT_VALUE)
+        radio_mode_text = slots.get(RADIO_MODE_SLOT, {}).get(SLOT_VALUE, "")
         radio_mode = False
+        if radio_mode_text:
+            radio_mode = True
         if query:
             if not config_entry.data.get(CONF_OPENAI_AGENT_ID):
                 raise intent.IntentHandleError(

--- a/custom_components/mass/media_player.py
+++ b/custom_components/mass/media_player.py
@@ -102,9 +102,9 @@ ATTR_SOURCE_PLAYER = "source_player"
 ATTR_AUTO_PLAY = "auto_play"
 
 
-def catch_musicassistant_error[
-    _R, **P
-](func: Callable[..., Awaitable[_R]],) -> Callable[..., Coroutine[Any, Any, _R | None]]:
+def catch_musicassistant_error[_R, **P](
+    func: Callable[..., Awaitable[_R]],
+) -> Callable[..., Coroutine[Any, Any, _R | None]]:
     """Check and log commands to players."""
 
     @functools.wraps(func)

--- a/custom_components/mass/media_player.py
+++ b/custom_components/mass/media_player.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
 SUPPORTED_FEATURES = (
     MediaPlayerEntityFeature.PAUSE
     | MediaPlayerEntityFeature.VOLUME_SET
+    | MediaPlayerEntityFeature.VOLUME_MUTE
     | MediaPlayerEntityFeature.STOP
     | MediaPlayerEntityFeature.PREVIOUS_TRACK
     | MediaPlayerEntityFeature.NEXT_TRACK
@@ -101,9 +102,9 @@ ATTR_SOURCE_PLAYER = "source_player"
 ATTR_AUTO_PLAY = "auto_play"
 
 
-def catch_musicassistant_error[_R, **P](
-    func: Callable[..., Awaitable[_R]],
-) -> Callable[..., Coroutine[Any, Any, _R | None]]:
+def catch_musicassistant_error[
+    _R, **P
+](func: Callable[..., Awaitable[_R]],) -> Callable[..., Coroutine[Any, Any, _R | None]]:
     """Check and log commands to players."""
 
     @functools.wraps(func)

--- a/custom_sentences/en/music_assistant_PlayMediaAssist.yaml
+++ b/custom_sentences/en/music_assistant_PlayMediaAssist.yaml
@@ -37,6 +37,23 @@ intents:
         requires_context:
           domain: "media_player"
 
+      # TARGET AN AREA AND A NAME
+      - sentences:
+          - "<play> <artist> {artist} in [the ]<area> <on> [the ]{name} [<player_devices>] [((with)|(using)) {radio_mode}]"
+          - "<play> <album> {album} [by <artist> {artist}] in [the ]<area> <on> [the ]{name} [<player_devices>] [((with)|(using)) {radio_mode}]"
+          - "<play> <track> {track} [by <artist> {artist}] in [the ]<area> <on> [the ]{name} [<player_devices>][((with)|(using)) {radio_mode}]"
+          - "<play> <playlist> {playlist} in [the ]<area> <on> [the ]{name} [<player_devices>][((with)|(using)) {radio_mode}]"
+          - "<play> <radio_station> {radio} in [the ]<area> <on> [the ]{name} [<player_devices>]"
+        expansion_rules:
+          play: "((play)|(listen to))"
+          player_devices: "((speaker)|([media] player))"
+          "on": "(on|using)"
+          artist: "[the ](artist|band|group)"
+          track: "[the ](track|song)"
+          album: "[the ](album|ep|record|compilation|single)"
+          playlist: "[the ]playlist"
+          radio_station: "[the ]((radio station)|(radio)|(station))"    
+
       # CONTEXT AWARNESS
       - sentences:
           - "<play> <artist> {artist} [((with)|(using)) {radio_mode}]"

--- a/custom_sentences/en/music_assistant_PlayMediaAssist.yaml
+++ b/custom_sentences/en/music_assistant_PlayMediaAssist.yaml
@@ -14,7 +14,7 @@ intents:
           play: "((play)|(listen to))"
           artist: "[the ](artist|band|group)"
           track: "[the ](track|song)"
-          album: "[the ](album|ep|record)"
+          album: "[the ](album|ep|record|compilation|single)"
           playlist: "[the ]playlist"
           radio_station: "[the ]((radio station)|(radio)|(station))"
 
@@ -31,7 +31,7 @@ intents:
           "on": "(on|using)"
           artist: "[the ](artist|band|group)"
           track: "[the ](track|song)"
-          album: "[the ](album|ep|record)"
+          album: "[the ](album|ep|record|compilation|single)"
           playlist: "[the ]playlist"
           radio_station: "[the ]((radio station)|(radio)|(station))"
         requires_context:
@@ -48,7 +48,7 @@ intents:
           play: "((play)|(listen to))"
           artist: "[the ](artist|band|group)"
           track: "[the ](track|song)"
-          album: "[the ](album|ep|record)"
+          album: "[the ](album|ep|record|compilation|single)"
           playlist: "[the ]playlist"
           radio_station: "[the ]((radio station)|(radio)|(station))"
         requires_context:

--- a/custom_sentences/en/music_assistant_PlayMediaAssist.yaml
+++ b/custom_sentences/en/music_assistant_PlayMediaAssist.yaml
@@ -5,10 +5,10 @@ intents:
 
       # TARGET AN AREA
       - sentences:
-          - "<play> <artist> {artist} in [the ]<area>"
-          - "<play> <album> {album} [by <artist> {artist}] in [the ]<area>"
-          - "<play> <track> {track} [by <artist> {artist}] in [the ]<area>"
-          - "<play> <playlist> {playlist} in [the ]<area>"
+          - "<play> <artist> {artist} in [the ]<area> [((with)|(using)) {radio_mode}]"
+          - "<play> <album> {album} [by <artist> {artist}] in [the ]<area> [((with)|(using)) {radio_mode}]"
+          - "<play> <track> {track} [by <artist> {artist}] in [the ]<area> [((with)|(using)) {radio_mode}]"
+          - "<play> <playlist> {playlist} in [the ]<area> [((with)|(using)) {radio_mode}]"
           - "<play> <radio_station> {radio} in [the ]<area>"
         expansion_rules:
           play: "((play)|(listen to))"
@@ -20,10 +20,10 @@ intents:
 
       # TARGET A NAME
       - sentences:
-          - "<play> <artist> {artist} <on> [the ]{name} [<player_devices>]"
-          - "<play> <album> {album} [by <artist> {artist}] <on> [the ]{name} [<player_devices>]"
-          - "<play> <track> {track} [by <artist> {artist}] <on> [the ]{name} [<player_devices>]"
-          - "<play> <playlist> {playlist} <on> [the ]{name} [<player_devices>]"
+          - "<play> <artist> {artist} <on> [the ]{name} [<player_devices>] [((with)|(using)) {radio_mode}]"
+          - "<play> <album> {album} [by <artist> {artist}] <on> [the ]{name} [<player_devices>] [((with)|(using)) {radio_mode}]"
+          - "<play> <track> {track} [by <artist> {artist}] <on> [the ]{name} [<player_devices>] [((with)|(using)) {radio_mode}]"
+          - "<play> <playlist> {playlist} <on> [the ]{name} [<player_devices>] [((with)|(using)) {radio_mode}]"
           - "<play> <radio_station> {radio} <on> [the ]{name} [<player_devices>]"
         expansion_rules:
           play: "((play)|(listen to))"
@@ -39,10 +39,10 @@ intents:
 
       # CONTEXT AWARNESS
       - sentences:
-          - "<play> <artist> {artist}"
-          - "<play> <album> {album} [by <artist> {artist}]"
-          - "<play> <track> {track} [by <artist> {artist}]"
-          - "<play> <playlist> {playlist}"
+          - "<play> <artist> {artist} [((with)|(using)) {radio_mode}]"
+          - "<play> <album> {album} [by <artist> {artist}] [((with)|(using)) {radio_mode}]"
+          - "<play> <track> {track} [by <artist> {artist}] [((with)|(using)) {radio_mode}]"
+          - "<play> <playlist> {playlist} [((with)|(using)) {radio_mode}]"
           - "<play> <radio_station> {radio}"
         expansion_rules:
           play: "((play)|(listen to))"
@@ -65,3 +65,6 @@ lists:
     wildcard: true
   radio:
     wildcard: true
+  radio_mode:
+    values:
+      - "radio mode"

--- a/custom_sentences/en/music_assistant_PlayMediaAssist.yaml
+++ b/custom_sentences/en/music_assistant_PlayMediaAssist.yaml
@@ -52,7 +52,7 @@ intents:
           track: "[the ](track|song)"
           album: "[the ](album|ep|record|compilation|single)"
           playlist: "[the ]playlist"
-          radio_station: "[the ]((radio station)|(radio)|(station))"    
+          radio_station: "[the ]((radio station)|(radio)|(station))"
 
       # CONTEXT AWARNESS
       - sentences:

--- a/custom_sentences/en/play_media_on_media_player.yaml
+++ b/custom_sentences/en/play_media_on_media_player.yaml
@@ -9,7 +9,7 @@ intents:
         expansion_rules:
           play: "((play)|(listen to))"
 
-      # TARGET A NAME    
+      # TARGET A NAME
       - sentences:
           - "<play> {query};<on> [the ]{name} [<player_devices>] [((with)|(using)) {radio_mode}]"
         expansion_rules:
@@ -19,7 +19,7 @@ intents:
         requires_context:
           domain: "media_player"
 
-      # TARGET AN AREA AND A NAME    
+      # TARGET AN AREA AND A NAME
       - sentences:
           - "<play> {query};in [the ]<area> <on> [the ]{name} [<player_devices>] [((with)|(using)) {radio_mode}]"
         expansion_rules:
@@ -28,7 +28,7 @@ intents:
           "on": "(on|using)"
         requires_context:
           domain: "media_player"
-   
+
 lists:
   query:
     wildcard: true

--- a/custom_sentences/en/play_media_on_media_player.yaml
+++ b/custom_sentences/en/play_media_on_media_player.yaml
@@ -2,12 +2,14 @@ language: "en"
 intents:
   MassPlayMediaOnMediaPlayer:
     data:
+  
+      # TARGET AN AREA
       - sentences:
           - "<play> {query};in [the ]<area> [((with)|(using)) {radio_mode}]"
         expansion_rules:
           play: "((play)|(listen to))"
-          player_devices: "((speaker)|([media] player))"
-          "on": "(on|using)"
+
+      # TARGET A NAME    
       - sentences:
           - "<play> {query};<on> [the ]{name} [<player_devices>] [((with)|(using)) {radio_mode}]"
         expansion_rules:
@@ -16,6 +18,17 @@ intents:
           "on": "(on|using)"
         requires_context:
           domain: "media_player"
+
+      # TARGET AN AREA AND A NAME    
+      - sentences:
+          - "<play> {query};in [the ]<area> <on> [the ]{name} [<player_devices>] [((with)|(using)) {radio_mode}]"
+        expansion_rules:
+          play: "((play)|(listen to))"
+          player_devices: "((speaker)|([media] player))"
+          "on": "(on|using)"
+        requires_context:
+          domain: "media_player"
+   
 lists:
   query:
     wildcard: true

--- a/custom_sentences/en/play_media_on_media_player.yaml
+++ b/custom_sentences/en/play_media_on_media_player.yaml
@@ -34,4 +34,4 @@ lists:
     wildcard: true
   radio_mode:
     values:
-      - "radio mode"  
+      - "radio mode"

--- a/custom_sentences/en/play_media_on_media_player.yaml
+++ b/custom_sentences/en/play_media_on_media_player.yaml
@@ -2,7 +2,7 @@ language: "en"
 intents:
   MassPlayMediaOnMediaPlayer:
     data:
-  
+
       # TARGET AN AREA
       - sentences:
           - "<play> {query};in [the ]<area> [((with)|(using)) {radio_mode}]"

--- a/custom_sentences/en/play_media_on_media_player.yaml
+++ b/custom_sentences/en/play_media_on_media_player.yaml
@@ -3,13 +3,13 @@ intents:
   MassPlayMediaOnMediaPlayer:
     data:
       - sentences:
-          - "<play> {query};in [the ]<area>"
+          - "<play> {query};in [the ]<area> [((with)|(using)) {radio_mode}]"
         expansion_rules:
           play: "((play)|(listen to))"
           player_devices: "((speaker)|([media] player))"
           "on": "(on|using)"
       - sentences:
-          - "<play> {query};<on> [the ]{name} [<player_devices>]"
+          - "<play> {query};<on> [the ]{name} [<player_devices>] [((with)|(using)) {radio_mode}]"
         expansion_rules:
           play: "((play)|(listen to))"
           player_devices: "((speaker)|([media] player))"
@@ -19,3 +19,6 @@ intents:
 lists:
   query:
     wildcard: true
+  radio_mode:
+    values:
+      - "radio mode"  


### PR DESCRIPTION
Allows the use of radio mode for intents, also adds NAME in AREA to allow targeting a player in a given area. This allows users to have more than one player per area, which previously caused an error. 